### PR TITLE
Include tests data in covid 19 data.

### DIFF
--- a/api/covid19find/__init__.py
+++ b/api/covid19find/__init__.py
@@ -20,8 +20,9 @@ def create_app():
     data_repo = CovidDataRepository(os.environ.get("DATA_DIR", "/tmp"))
 
     def update_covid_data():
-        app.logger.info("Updating COVID-19 data")
+        app.logger.info("Updating COVID-19 data.")
         data_repo.update_data()
+        app.logger.info("Finished updating COVID-19 data.")
 
     country_repo = CountryRepository()
 


### PR DESCRIPTION
This adds new fields in country timeseries data` newTests`, `newTestsPositiveProportion`, `totalTests` and `totalTests` in overview.
New response for `/api/covid19data/{country_code}` call:

```json
{
  "currentActive": 3128,
  "timeseries": [
    {
      "currentActive": 3264,
      "date": "2020-08-19",
      "newConfirmed": 311,
      "newDeaths": 4,
      "newRecovered": 0,
      "newTests": 10785,
      "newTestsPositiveProportion": 0.028836346777932315,
      "totalConfirmed": 38760,
      "totalDeaths": 1996,
      "totalRecovered": 33500,
      "totalTests": 901074
    },
    {
      "currentActive": 3128,
      "date": "2020-08-20",
      "newConfirmed": 266,
      "newDeaths": 2,
      "newRecovered": 400,
      "newTests": 9209,
      "newTestsPositiveProportion": 0.028884786621783037,
      "totalConfirmed": 39026,
      "totalDeaths": 1998,
      "totalRecovered": 33900,
      "totalTests": 910283
    }
  ],
  "totalConfirmed": 39026,
  "totalDeaths": 1998,
  "totalRecovered": 33900,
  "totalTests": 910283
}
```