### PR TITLE
Fix bubble chart scaling

### DIFF
--- a/app/components/SimulationResults/index.tsx
+++ b/app/components/SimulationResults/index.tsx
@@ -26,12 +26,13 @@ const SCALE_VALUE = 3;
 
 /*
  Scales the value by 10s according to the max digit
+ in order to fit these large numbers as radius 
+ for bubbles on a the client screen in pixels
  if max digit is 200,000,000
  then a value with 1,000,000
  will look like 1
  and 150,000,000
  will look like 150
- not sure if this is a a good idea...
 */
 function scaleValueFromLargestValue(value: number, largestValue: number) {
   const digits = Math.floor(largestValue).toString().length;
@@ -297,10 +298,12 @@ const SimulationResults: React.FC<{
 
                           // this is a grim line of code.
                           // we need to scale deaths down to a viewable scale
-                          data.r = scaleValueFromLargestValue(
-                            data.r,
-                            largestDeathsValue,
-                          );
+                          data.r =
+                            scaleValueFromLargestValue(
+                              data.r,
+                              largestDeathsValue,
+                            ) / 2;
+
                           // The x axis will show the total number of infected, y axis the total number of people in isolation, and the diameter of the circle will be proportional to the total number of deaths
                           return {
                             data: [data],


### PR DESCRIPTION
resolves: #109 

Fix bubble chart scaling. 

I've changed the algorithm that scales the deaths to be scaled to an appropriate clientWidth px value, where max px value is less than 1000px.

<img width="1201" alt="Screenshot 2020-09-13 at 12 25 41" src="https://user-images.githubusercontent.com/5485824/93015829-e0a83c00-f5bc-11ea-8b03-00c1d00503e3.png">

NOTE: The graph here looks strange only because the scenarios return the same value, and `newIsolated` values are always returned as 0 from the simulation. If there's more variety the graph should look a little better. 


NOTE 2: it's important for someone to check to see if the data I'm presenting in these charts are the correct value. I am accumulating some values to present this data, and I'd like some extra eyes to maybe check to see if I'm accumulating the correct values (@dhaneshnm ), for example using `newDeaths` instead of `totalDeaths`. Previously I was accumulating `totalDeaths` and I think it presented a ridiculous number of total deaths in the population, some 29 million for the swiss population of 8mil, for example. 