### PR TITLE
truncate long label strings on the comparison graphs

### DIFF
--- a/app/components/SimulationResults/index.tsx
+++ b/app/components/SimulationResults/index.tsx
@@ -20,6 +20,7 @@ import colors from '../../colors';
 import AwaitingInput from './AwaitingInput';
 
 import './simulation-results.less';
+import { truncate } from '../../libs/strings';
 
 const SCALE_VALUE = 3;
 
@@ -373,6 +374,13 @@ const SimulationResults: React.FC<{
                                         color: '#00000005',
                                       },
                                       ticks: {
+                                        callback: value => {
+                                          const MAX_CHAR_LENGTH = 10;
+                                          return truncate(
+                                            value,
+                                            MAX_CHAR_LENGTH,
+                                          );
+                                        },
                                         maxRotation: isMobile ? 90 : 0, // angle in degrees
                                       },
                                     },

--- a/app/libs/strings.ts
+++ b/app/libs/strings.ts
@@ -4,3 +4,10 @@ export function toLetters(num: number): string {
   const out = mod ? String.fromCharCode(64 + mod) : (--pow, 'Z');
   return pow ? toLetters(pow) + out : out;
 }
+
+export function truncate(input: string, maxLength: number) {
+  if (input.length > maxLength) {
+    return input.substring(0, maxLength) + '...';
+  }
+  return input;
+}


### PR DESCRIPTION

<img width="1128" alt="Screenshot 2020-09-13 at 13 54 20" src="https://user-images.githubusercontent.com/5485824/93017407-d2601d00-f5c8-11ea-9ba4-c282dfcb93b6.png">
resolves #104 