### PR TITLE
fix input number type to use string & fix default value

### DIFF
--- a/app/components/ScenarioEditor/PhaseNumberInput.tsx
+++ b/app/components/ScenarioEditor/PhaseNumberInput.tsx
@@ -5,20 +5,25 @@ import './phase-input.less';
 
 const PhaseNumberInput: React.FC<{
   inputProps: NumberInputProp;
-  onChange: (number) => void;
+  onChange: (number: number) => void;
   value: number;
 }> = ({ inputProps, onChange, value: defaultValue }) => {
   const ref = React.useRef<HTMLInputElement>(null);
-  const [inputValue, setInputValue] = React.useState(defaultValue.toString());
+  const [inputValue, setInputValue] = React.useState<string>(
+    defaultValue.toString(),
+  );
+
   React.useEffect(() => {
     setInputValue(defaultValue.toString());
   }, [defaultValue]);
+
   const handleBlur = () => {
-    onChange(inputValue);
+    onChange(Number(inputValue));
   };
   const handleChange = () => {
     setInputValue(ref?.current.value);
   };
+
   return (
     <input
       className="phase number"


### PR DESCRIPTION
Fixes a problem where loading scenarios doesn't update the values represented in the UI, but still would keep the correct value stored behind the scenes. 

This is because 
1. html input tags always return strings, even for number type (new to me!)
2. I was using only the defaultValue prop, which doesn't update the UI on upates. 