### PR TITLE
fix trace options

### DIFF
--- a/app/components/ScenarioEditor/phaseForm.ts
+++ b/app/components/ScenarioEditor/phaseForm.ts
@@ -117,6 +117,10 @@ export default [
             value: 0.1,
           },
           {
+            label: '20%',
+            value: 0.2,
+          },
+          {
             label: '25%',
             value: 0.25,
           },


### PR DESCRIPTION
The default scenarios have been changed to a value which is not available in the UI, making it look blank. I've added the value that's returned by the scenario to the options list for this property.  