### PR TITLE
remove graph tension in lives saved

### DIFF
--- a/app/components/SimulationResults/Graphs/LivesSaved.tsx
+++ b/app/components/SimulationResults/Graphs/LivesSaved.tsx
@@ -111,6 +111,8 @@ const LivesSaved: React.FC<{
               ),
             }));
             return {
+              lineTension: 0,
+
               label: clientScenariosInput[index].name,
               data: scenario.testingImpact.map(entry => entry.livesSaved),
               borderColor: COLORS_BY_SCENARIO_INDEX[index],


### PR DESCRIPTION
resolves: #209 

resolved by removing the tension of the bezier curve of the line graph. 

![image](https://user-images.githubusercontent.com/5485824/107392810-5972dc00-6afa-11eb-9ceb-7a99d328400f.png)
